### PR TITLE
Add Sunder Geirskogul

### DIFF
--- a/Configuration.cs
+++ b/Configuration.cs
@@ -139,6 +139,7 @@ public class Configuration : PluginConfiguration<Configuration>, IPluginConfigur
     public bool EnableDecomboLiturgy = false;
     public bool EnableDecomboEarthlyStar = false;
     public bool EnableDecomboMinorArcana = false;
+    public bool EnableDecomboGeirskogul = false;
 
     public override void Initialize()
     {

--- a/Modules/Decombos.cs
+++ b/Modules/Decombos.cs
@@ -22,7 +22,9 @@ public unsafe class Decombos : PluginModule
 
         Minor_Arcana = 7443,
         Lord_of_Crowns = 7444,
-        Lady_of_Crowns = 7445
+        Lady_of_Crowns = 7445,
+
+        Geirskogul = 3555
     }
 
     public override bool ShouldEnable => ReAction.Config.EnableDecomboMeditation
@@ -30,7 +32,8 @@ public unsafe class Decombos : PluginModule
         || ReAction.Config.EnableDecomboWanderersMinuet
         || ReAction.Config.EnableDecomboLiturgy
         || ReAction.Config.EnableDecomboEarthlyStar
-        || ReAction.Config.EnableDecomboMinorArcana;
+        || ReAction.Config.EnableDecomboMinorArcana
+        || ReAction.Config.EnableDecomboGeirskogul;
 
     protected override void Enable() => GetAdjustedActionIdHook.Enable();
     protected override void Disable() => GetAdjustedActionIdHook.Disable();
@@ -69,6 +72,9 @@ public unsafe class Decombos : PluginModule
             case ActionID.Lady_of_Crowns when ReAction.Config.EnableDecomboMinorArcana:
                 var minorArcanaAdjustment = GetAdjustedActionIdHook.Original(actionManager, ActionID.Minor_Arcana);
                 return minorArcanaAdjustment != ActionID.Minor_Arcana ? minorArcanaAdjustment : actionID;
+
+            case ActionID.Geirskogul when ReAction.Config.EnableDecomboGeirskogul:
+                return actionID;
 
             default:
                 return ret;

--- a/PluginUI.cs
+++ b/PluginUI.cs
@@ -552,6 +552,9 @@ public static class PluginUI
             save |= ImGui.Checkbox("Sunder Minor Arcana", ref ReAction.Config.EnableDecomboMinorArcana);
             ImGuiEx.SetItemTooltip("Removes the Minor Arcana -> Lord / Lady of Crowns combo. You will need to use the\nhotbar feature below to place one of them on your hotbar in order to use them again.\nLord of Crowns ID: 7444\nLady of Crowns ID: 7445");
 
+            save |= ImGui.Checkbox("Sunder Geirskogul", ref ReAction.Config.EnableDecomboGeirskogul);
+            ImGuiEx.SetItemTooltip("Removes the Geirskogul -> Nastrond combo. You will need to use the\nhotbar feature below to place it on your hotbar in order to use it again.\nNastrond ID: 7400");
+
             ImGuiEx.EndGroupBox();
         }
 


### PR DESCRIPTION
Adds the option to decombo Geirskogul from Nastrond.
This will prevent accidental Nastrond uses at the start of the life window and fix the Geirskogul queueing issues at the end of it.
I tested for a while and had no issues so far.