### PR TITLE
Update `ReAction` for API 11, `Lumina.Excel` updates, and update "additional recast group" signature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ obj/
 bin/
 
 Publish/
+
+/Hypostasis

--- a/ActionStackManager.cs
+++ b/ActionStackManager.cs
@@ -56,7 +56,7 @@ public static unsafe class ActionStackManager
                     if (!stack.Actions.Any(action
                             => action.ID == 0
                                || action.ID == 1 && a.CanTargetHostile
-                               || action.ID == 2 && (a.CanTargetFriendly || a.CanTargetParty)
+                               || action.ID == 2 && (a.CanTargetAlly || a.CanTargetParty)
                                || (action.UseAdjustedID ? actionManager->CS.GetAdjustedActionId(action.ID) : action.ID) == adjustedActionID))
                         continue;
 

--- a/Modules/EnhancedAutoFaceTarget.cs
+++ b/Modules/EnhancedAutoFaceTarget.cs
@@ -1,5 +1,5 @@
 using Hypostasis.Game.Structures;
-using Lumina.Excel.GeneratedSheets;
+using Lumina.Excel.Sheets;
 
 namespace ReAction.Modules;
 

--- a/Modules/QueueAdjustments.cs
+++ b/Modules/QueueAdjustments.cs
@@ -64,7 +64,7 @@ public unsafe class QueueAdjustments : PluginModule
         isRequeuing = false;
     }
 
-    [HypostasisSignatureInjection("E8 ?? ?? ?? ?? 8B 4F 44 33 D2", Required = true)]
+    [HypostasisSignatureInjection("E8 ?? ?? ?? ?? 8B 4F 44 33 D2 ?? ?? ?? ?? ?? ??", Required = true)]
     private static delegate* unmanaged<ActionManager*, uint, uint, int> getAdditionalRecastGroup;
 
     [HypostasisSignatureInjection("E8 ?? ?? ?? ?? 84 C0 74 10 48 83 FF 0F", Required = true)]

--- a/Modules/QueueMore.cs
+++ b/Modules/QueueMore.cs
@@ -1,5 +1,5 @@
 using Hypostasis.Game.Structures;
-using Lumina.Excel.GeneratedSheets;
+using Lumina.Excel.Sheets;
 
 namespace ReAction.Modules;
 
@@ -56,14 +56,14 @@ public unsafe class QueueMore : PluginModule
     {
         allowQueuingPatch.Disable();
 
-        if (ret && DalamudApi.DataManager.GetExcelSheet<Action>()?.GetRow(adjustedActionID) is { ActionCategory.Row: 9 or 15 })
+        if (ret && DalamudApi.DataManager.GetExcelSheet<Action>()?.GetRow(adjustedActionID) is { ActionCategory.RowId: 9 or 15 })
             lastLBSequence = actionManager->currentSequence;
     }
 
     private static bool CheckAction(uint actionType, uint actionID, uint adjustedActionID) =>
         actionType switch
         {
-            1 when DalamudApi.DataManager.GetExcelSheet<Action>()?.GetRow(adjustedActionID) is { ActionCategory.Row: 9 or 15 } => lastLBSequence != Common.ActionManager->currentSequence, // Allow LB
+            1 when DalamudApi.DataManager.GetExcelSheet<Action>()?.GetRow(adjustedActionID) is { ActionCategory.RowId: 9 or 15 } => lastLBSequence != Common.ActionManager->currentSequence, // Allow LB
             2 => true, // Allow items
             5 when actionID == 4 => true, // Allow Sprint
             _ => false

--- a/PluginUI.cs
+++ b/PluginUI.cs
@@ -6,8 +6,8 @@ using Dalamud.Interface.Utility;
 using FFXIVClientStructs.FFXIV.Client.UI.Misc;
 using Hypostasis.Game.Structures;
 using ImGuiNET;
-using Lumina.Excel.GeneratedSheets;
-using Action = Lumina.Excel.GeneratedSheets.Action;
+using Lumina.Excel.Sheets;
+using Action = Lumina.Excel.Sheets.Action;
 
 namespace ReAction;
 
@@ -226,7 +226,7 @@ public static class PluginUI
         0 => "All Actions",
         1 => "All Harmful Actions",
         2 => "All Beneficial Actions",
-        _ => $"[#{a.RowId} {a.ClassJob.Value?.Abbreviation}{(a.IsPvP ? " PVP" : string.Empty)}] {a.Name}"
+        _ => $"[#{a.RowId} {a.ClassJob.ValueNullable?.Abbreviation}{(a.IsPvP ? " PVP" : string.Empty)}] {a.Name}"
     };
 
     private static readonly ImGuiEx.ExcelSheetComboOptions<Action> actionComboOptions = new()
@@ -304,7 +304,7 @@ public static class PluginUI
     private static string FormatOverrideActionRow(Action a) => a.RowId switch
     {
         0 => "Same Action",
-        _ => $"[#{a.RowId} {a.ClassJob.Value?.Abbreviation}{(a.IsPvP ? " PVP" : string.Empty)}] {a.Name}"
+        _ => $"[#{a.RowId} {a.ClassJob.ValueNullable?.Abbreviation}{(a.IsPvP ? " PVP" : string.Empty)}] {a.Name}"
     };
 
     private static readonly ImGuiEx.ExcelSheetComboOptions<Action> actionOverrideComboOptions = new()
@@ -684,7 +684,7 @@ public static class PluginUI
                 ImGuiEx.ExcelSheetCombo($"ID##{commandType}", ref commandID, new ImGuiEx.ExcelSheetComboOptions<FieldMarker> { FormatRow = r => $"[#{r.RowId}] {r.Name}" });
                 break;
             case RaptureHotbarModule.HotbarSlotType.Recipe:
-                ImGuiEx.ExcelSheetCombo($"ID##{commandType}", ref commandID, new ImGuiEx.ExcelSheetComboOptions<Recipe> { FormatRow = r => $"[#{r.RowId}] {r.ItemResult.Value?.Name}" });
+                ImGuiEx.ExcelSheetCombo($"ID##{commandType}", ref commandID, new ImGuiEx.ExcelSheetComboOptions<Recipe> { FormatRow = r => $"[#{r.RowId}] {r.ItemResult.ValueNullable?.Name}" });
                 break;
             case RaptureHotbarModule.HotbarSlotType.ChocoboRaceAbility:
                 ImGuiEx.ExcelSheetCombo($"ID##{commandType}", ref commandID, new ImGuiEx.ExcelSheetComboOptions<ChocoboRaceAbility> { FormatRow = r => $"[#{r.RowId}] {r.Name}" });
@@ -711,7 +711,7 @@ public static class PluginUI
                 ImGuiEx.ExcelSheetCombo($"ID##{commandType}", ref commandID, new ImGuiEx.ExcelSheetComboOptions<Perform> { FormatRow = r => $"[#{r.RowId}] {r.Instrument}" });
                 break;
             case RaptureHotbarModule.HotbarSlotType.McGuffin:
-                ImGuiEx.ExcelSheetCombo($"ID##{commandType}", ref commandID, new ImGuiEx.ExcelSheetComboOptions<McGuffin> { FormatRow = r => $"[#{r.RowId}] {r.UIData.Value?.Name}" });
+                ImGuiEx.ExcelSheetCombo($"ID##{commandType}", ref commandID, new ImGuiEx.ExcelSheetComboOptions<McGuffin> { FormatRow = r => $"[#{r.RowId}] {r.UIData.ValueNullable?.Name}" });
                 break;
             case RaptureHotbarModule.HotbarSlotType.Ornament:
                 ImGuiEx.ExcelSheetCombo($"ID##{commandType}", ref commandID, new ImGuiEx.ExcelSheetComboOptions<Ornament> { FormatRow = r => $"[#{r.RowId}] {r.Singular}" });

--- a/PronounManager.cs
+++ b/PronounManager.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using FFXIVClientStructs.FFXIV.Client.Game.Character;
 using FFXIVClientStructs.FFXIV.Client.Game.Control;
 using FFXIVClientStructs.FFXIV.Client.Game.Object;
-using Lumina.Excel.GeneratedSheets;
+using Lumina.Excel.Sheets;
 
 namespace ReAction;
 
@@ -20,11 +20,11 @@ public static unsafe class PronounHelpers
     public static GameObject* GetPartyMemberByClassJobID(byte classJob) => (GameObject*)Common.GetPartyMembers().Skip(1).FirstOrDefault(address => ((Character*)address)->CharacterData.ClassJob == classJob);
 
     public static GameObject* GetPartyMemberByRoleID(byte role) => DalamudApi.DataManager.GetExcelSheet<ClassJob>() is { } sheet
-        ? (GameObject*)Common.GetPartyMembers().Skip(1).FirstOrDefault(address => sheet.GetRow(((Character*)address)->CharacterData.ClassJob)?.Role == role)
+        ? (GameObject*)Common.GetPartyMembers().Skip(1).FirstOrDefault(address => sheet.GetRow(((Character*)address)->CharacterData.ClassJob).Role == role)
         : null;
 
     public static GameObject* GetPartyMemberByLimitBreak1(uint actionID) => DalamudApi.DataManager.GetExcelSheet<ClassJob>() is { } sheet
-        ? (GameObject*)Common.GetPartyMembers().Skip(1).FirstOrDefault(address => sheet.GetRow(((Character*)address)->CharacterData.ClassJob)?.LimitBreak1.Row == actionID)
+        ? (GameObject*)Common.GetPartyMembers().Skip(1).FirstOrDefault(address => sheet.GetRow(((Character*)address)->CharacterData.ClassJob).LimitBreak1.RowId == actionID)
         : null;
 }
 

--- a/ReAction.cs
+++ b/ReAction.cs
@@ -7,16 +7,16 @@ namespace ReAction;
 
 public class ReAction(IDalamudPluginInterface pluginInterface) : DalamudPlugin<Configuration>(pluginInterface), IDalamudPlugin
 {
-    public static Dictionary<uint, Lumina.Excel.GeneratedSheets.Action> actionSheet;
-    public static Dictionary<uint, Lumina.Excel.GeneratedSheets.Action> mountActionsSheet;
+    public static Dictionary<uint, Lumina.Excel.Sheets.Action> actionSheet;
+    public static Dictionary<uint, Lumina.Excel.Sheets.Action> mountActionsSheet;
 
     protected override void Initialize()
     {
         Game.Initialize();
         PronounManager.Initialize();
 
-        actionSheet = DalamudApi.DataManager.GetExcelSheet<Lumina.Excel.GeneratedSheets.Action>()?.Where(i => i.ClassJobCategory.Row > 0 && i.ActionCategory.Row <= 4 && i.RowId > 8).ToDictionary(i => i.RowId, i => i);
-        mountActionsSheet = DalamudApi.DataManager.GetExcelSheet<Lumina.Excel.GeneratedSheets.Action>()?.Where(i => i.ActionCategory.Row == 12).ToDictionary(i => i.RowId, i => i);
+        actionSheet = DalamudApi.DataManager.GetExcelSheet<Lumina.Excel.Sheets.Action>()?.Where(i => i.ClassJobCategory.RowId > 0 && i.ActionCategory.RowId <= 4 && i.RowId > 8).ToDictionary(i => i.RowId, i => i);
+        mountActionsSheet = DalamudApi.DataManager.GetExcelSheet<Lumina.Excel.Sheets.Action>()?.Where(i => i.ActionCategory.RowId == 12).ToDictionary(i => i.RowId, i => i);
         if (actionSheet == null || mountActionsSheet == null)
             throw new ApplicationException("Action sheet failed to load!");
     }

--- a/ReAction.csproj
+++ b/ReAction.csproj
@@ -16,7 +16,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="DalamudPackager" Version="2.1.13" />
+        <PackageReference Include="DalamudPackager" Version="11.0.0" />
         <Reference Include="FFXIVClientStructs">
             <HintPath>$(DalamudLibPath)FFXIVClientStructs.dll</HintPath>
             <Private>false</Private>

--- a/ReAction.json
+++ b/ReAction.json
@@ -12,6 +12,5 @@
     "jobs"
   ],
   "InternalName": "ReAction",
-  "AssemblyVersion": "9.9.9.9",
   "Changelog": "Fixed an issue with queuing some charged actions."
 }


### PR DESCRIPTION
Hi, these are the minimum changes that I found to get `ReAction` working after various game and library updates. 

Please note that I did not include changes to hard-coded action IDs as I'm not entirely certain what is needed where, but changing those locally to (what I assume are the correct) certain values allows the plugin to build and load in-game successfully. The only modules still broken following my local changes are `EnhancedFaceAutoTarget` and `SpellAutoAttacks` as I don't know how you determine the ASM needed for those patches.